### PR TITLE
Feat: [meeting] CRD API 구현

### DIFF
--- a/src/main/java/com/codiapp/codi/CodiApplication.java
+++ b/src/main/java/com/codiapp/codi/CodiApplication.java
@@ -7,20 +7,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-public class CodiApplication implements CommandLineRunner {
+public class CodiApplication {
     public static void main(String[] args) {
         SpringApplication.run(CodiApplication.class, args);
-    }
-
-    @Override
-    public void run(String... args) {
-//        Hello hello = new Hello();
-//        hello.setId(1L);
-//        hello.setMessage("Hello Oracle!");
-//
-//        helloRepository.save(hello);
-
-        System.out.println(" 저장 완료!");
     }
 
 }

--- a/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package com.codiapp.codi.domain.meeting.controller;
 
 import com.codiapp.codi.domain.meeting.dto.request.MeetingCreateRequestDTO;
+import com.codiapp.codi.domain.meeting.dto.request.MeetingUpdateRequestDTO;
 import com.codiapp.codi.domain.meeting.dto.response.MeetingDetailResponseDTO;
 import com.codiapp.codi.domain.meeting.entity.Meeting;
 import com.codiapp.codi.domain.meeting.service.MeetingCommandService;
@@ -34,5 +35,18 @@ public class MeetingController {
     public ResponseEntity<MeetingDetailResponseDTO> getMeeting(@Parameter(description = "회의록 ID") @PathVariable Long id) {
         MeetingDetailResponseDTO dto = meetingQueryService.getMeetingDetail(id);
         return ResponseEntity.ok(dto);
+    }
+    @PatchMapping("/{meetingId}")
+    public ResponseEntity<Meeting> updateMeeting(
+            @PathVariable Long meetingId,
+            @RequestBody MeetingUpdateRequestDTO request
+    ) {
+        Meeting updated = meetingCommandService.updateMeeting(meetingId, request);
+        return ResponseEntity.ok(updated);
+    }
+    @DeleteMapping("/{meetingId}")
+    public ResponseEntity<Void> deleteMeeting(@PathVariable Long meetingId) {
+        meetingCommandService.deleteMeeting(meetingId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
@@ -1,0 +1,38 @@
+package com.codiapp.codi.domain.meeting.controller;
+
+import com.codiapp.codi.domain.meeting.dto.request.MeetingCreateRequestDTO;
+import com.codiapp.codi.domain.meeting.dto.response.MeetingDetailResponseDTO;
+import com.codiapp.codi.domain.meeting.entity.Meeting;
+import com.codiapp.codi.domain.meeting.service.MeetingCommandService;
+import com.codiapp.codi.domain.meeting.service.MeetingQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/meeting")
+@RequiredArgsConstructor
+@Tag(name = "회의록 API", description = "회의록 등록 및 조회")
+public class MeetingController {
+
+    private final MeetingCommandService meetingCommandService;
+    private final MeetingQueryService meetingQueryService;
+
+    @PostMapping
+    @Operation(summary = "회의록 생성", description = "회의 제목, 일시, 장소, 안건, 결정사항을 포함한 회의록을 생성합니다.")
+    public ResponseEntity<Long> createMeeting(@RequestBody MeetingCreateRequestDTO request) {
+        Meeting created = meetingCommandService.createMeeting(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created.getId());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "회의록 단일 조회", description = "회의록 ID를 이용해 회의록 상세 내용을 조회합니다.")
+    public ResponseEntity<MeetingDetailResponseDTO> getMeeting(@Parameter(description = "회의록 ID") @PathVariable Long id) {
+        MeetingDetailResponseDTO dto = meetingQueryService.getMeetingDetail(id);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/converter/MeetingConverter.java
@@ -1,0 +1,65 @@
+package com.codiapp.codi.domain.meeting.converter;
+
+import com.codiapp.codi.domain.meeting.dto.request.MeetingCreateRequestDTO;
+import com.codiapp.codi.domain.meeting.dto.response.AgendaResponseDTO;
+import com.codiapp.codi.domain.meeting.dto.response.MeetingDetailResponseDTO;
+import com.codiapp.codi.domain.meeting.entity.*;
+import com.codiapp.codi.domain.team.entity.Team;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MeetingConverter {
+
+    public static Meeting toMeeting(MeetingCreateRequestDTO request, Team team) {
+        Meeting meeting = Meeting.builder()
+                .title(request.title())
+                .dateTime(request.dateTime())
+                .location(request.location())
+                .team(team)
+                .build();
+
+        // 안건
+        request.agendas().forEach(agendaDTO -> {
+            Agenda agenda = Agenda.builder().title(agendaDTO.title()).build();
+            agendaDTO.details().forEach(detailContent -> {
+                AgendaDetail detail = AgendaDetail.builder().content(detailContent).build();
+                agenda.addDetail(detail);
+            });
+            meeting.addAgenda(agenda);
+        });
+
+        // 결정사항
+        request.decisions().forEach(content -> {
+            Decision decision = Decision.builder().content(content).build();
+            meeting.addDecision(decision);
+        });
+
+        return meeting;
+    }
+
+    public static MeetingDetailResponseDTO toMeetingDetailResponseDTO(Meeting meeting) {
+        List<AgendaResponseDTO> agendas = meeting.getAgendas().stream()
+                .map(agenda -> new AgendaResponseDTO(
+                        agenda.getTitle(),
+                        agenda.getDetails().stream()
+                                .map(AgendaDetail::getContent)
+                                .collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+
+        List<String> decisions = meeting.getDecisions().stream()
+                .map(Decision::getContent)
+                .collect(Collectors.toList());
+
+        return new MeetingDetailResponseDTO(
+                meeting.getTitle(),
+                meeting.getDateTime(),
+                meeting.getLocation(),
+                agendas,
+                decisions
+        );
+    }
+}
+
+

--- a/src/main/java/com/codiapp/codi/domain/meeting/dto/request/AgendaRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/dto/request/AgendaRequestDTO.java
@@ -1,0 +1,8 @@
+package com.codiapp.codi.domain.meeting.dto.request;
+
+import java.util.List;
+
+public record AgendaRequestDTO(
+        String title,
+        List<String> details
+) {}

--- a/src/main/java/com/codiapp/codi/domain/meeting/dto/request/MeetingCreateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/dto/request/MeetingCreateRequestDTO.java
@@ -1,0 +1,14 @@
+package com.codiapp.codi.domain.meeting.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingCreateRequestDTO(
+        Long teamId,
+        String title,
+        LocalDateTime dateTime,
+        String location,
+        List<AgendaRequestDTO> agendas,
+        List<String> decisions
+) {}
+

--- a/src/main/java/com/codiapp/codi/domain/meeting/dto/request/MeetingUpdateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/dto/request/MeetingUpdateRequestDTO.java
@@ -1,0 +1,12 @@
+package com.codiapp.codi.domain.meeting.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingUpdateRequestDTO(
+        String title,
+        LocalDateTime dateTime,
+        String location,
+        List<AgendaRequestDTO> agendas,
+        List<String> decisions
+) {}

--- a/src/main/java/com/codiapp/codi/domain/meeting/dto/response/AgendaResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/dto/response/AgendaResponseDTO.java
@@ -1,0 +1,8 @@
+package com.codiapp.codi.domain.meeting.dto.response;
+
+import java.util.List;
+
+public record AgendaResponseDTO(
+        String title,
+        List<String> details
+) {}

--- a/src/main/java/com/codiapp/codi/domain/meeting/dto/response/MeetingDetailResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/dto/response/MeetingDetailResponseDTO.java
@@ -1,0 +1,13 @@
+package com.codiapp.codi.domain.meeting.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingDetailResponseDTO(
+        String title,
+        LocalDateTime dateTime,
+        String location,
+        List<AgendaResponseDTO> agendas,
+        List<String> decisions
+) {}
+

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Agenda.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Agenda.java
@@ -1,0 +1,37 @@
+package com.codiapp.codi.domain.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Agenda {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long agendaId;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    @OneToMany(mappedBy = "agenda", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AgendaDetail> details = new ArrayList<>();
+
+    public void setMeeting(Meeting meeting) {
+        this.meeting = meeting;
+    }
+
+    public void addDetail(AgendaDetail detail) {
+        details.add(detail);
+        detail.setAgenda(this);
+    }
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Agenda.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Agenda.java
@@ -14,8 +14,9 @@ import java.util.List;
 public class Agenda {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "agenda_seq_gen")
+    @SequenceGenerator(name = "agenda_seq_gen", sequenceName = "AGENDA_SEQ", allocationSize = 1)
+    private Long id;
 
     private String title;
 
@@ -23,6 +24,7 @@ public class Agenda {
     @JoinColumn(name = "meeting_id")
     private Meeting meeting;
 
+    @Builder.Default
     @OneToMany(mappedBy = "agenda", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AgendaDetail> details = new ArrayList<>();
 

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Agenda.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Agenda.java
@@ -15,7 +15,7 @@ public class Agenda {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long agendaId;
+    private Long Id;
 
     private String title;
 

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/AgendaDetail.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/AgendaDetail.java
@@ -1,0 +1,27 @@
+package com.codiapp.codi.domain.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AgendaDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long agendaDetailId;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agenda_id")
+    private Agenda agenda;
+
+    public void setAgenda(Agenda agenda) {
+        this.agenda = agenda;
+    }
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/AgendaDetail.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/AgendaDetail.java
@@ -12,7 +12,7 @@ public class AgendaDetail {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long agendaDetailId;
+    private Long Id;
 
     @Column(columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/AgendaDetail.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/AgendaDetail.java
@@ -11,10 +11,12 @@ import lombok.*;
 public class AgendaDetail {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "agenda_detail_seq_gen")
+    @SequenceGenerator(name = "agenda_detail_seq_gen", sequenceName = "AGENDA_DETAIL_SEQ", allocationSize = 1)
+    private Long id;
 
-    @Column(columnDefinition = "TEXT")
+    @Lob
+    @Column
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Decision.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Decision.java
@@ -1,0 +1,27 @@
+package com.codiapp.codi.domain.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Decision {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long decisionId;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    public void setMeeting(Meeting meeting) {
+        this.meeting = meeting;
+    }
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Decision.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Decision.java
@@ -12,7 +12,7 @@ public class Decision {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long decisionId;
+    private Long Id;
 
     @Column(columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Decision.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Decision.java
@@ -9,12 +9,13 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class Decision {
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "decision_seq_gen")
+    @SequenceGenerator(name = "decision_seq_gen", sequenceName = "DECISION_SEQ", allocationSize = 1)
+    private Long id;
 
-    @Column(columnDefinition = "TEXT")
+    @Lob
+    @Column
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
@@ -1,0 +1,47 @@
+package com.codiapp.codi.domain.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Meeting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long meetingId;
+
+    private String title;
+
+    private LocalDateTime dateTime;
+
+    private String location;
+
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Agenda> agendas = new ArrayList<>();
+
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Decision> decisions = new ArrayList<>();
+
+    public void addAgenda(Agenda agenda) {
+        agendas.add(agenda);
+        agenda.setMeeting(this);
+    }
+
+    public void addDecision(Decision decision) {
+        decisions.add(decision);
+        decision.setMeeting(this);
+    }
+
+    public void update(String title, LocalDateTime dateTime, String location) {
+        this.title = title;
+        this.dateTime = dateTime;
+        this.location = location;
+    }
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
@@ -15,7 +15,7 @@ public class Meeting {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long meetingId;
+    private Long Id;
 
     private String title;
 

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.meeting.entity;
 
+import com.codiapp.codi.domain.team.entity.Team;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -22,6 +23,10 @@ public class Meeting {
     private LocalDateTime dateTime;
 
     private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
 
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Agenda> agendas = new ArrayList<>();

--- a/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/entity/Meeting.java
@@ -15,8 +15,9 @@ import java.util.List;
 public class Meeting {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "meeting_seq_gen")
+    @SequenceGenerator(name = "meeting_seq_gen", sequenceName = "MEETING_SEQ", allocationSize = 1)
+    private Long id;
 
     private String title;
 
@@ -28,9 +29,11 @@ public class Meeting {
     @JoinColumn(name = "team_id")
     private Team team;
 
+    @Builder.Default
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Agenda> agendas = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Decision> decisions = new ArrayList<>();
 

--- a/src/main/java/com/codiapp/codi/domain/meeting/repository/AgendaDetailRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/repository/AgendaDetailRepository.java
@@ -1,0 +1,7 @@
+package com.codiapp.codi.domain.meeting.repository;
+
+import com.codiapp.codi.domain.meeting.entity.AgendaDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgendaDetailRepository extends JpaRepository<AgendaDetail, Long> {
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/repository/AgendaRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/repository/AgendaRepository.java
@@ -1,0 +1,7 @@
+package com.codiapp.codi.domain.meeting.repository;
+
+import com.codiapp.codi.domain.meeting.entity.Agenda;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgendaRepository extends JpaRepository<Agenda, Long> {
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/repository/DecisionRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/repository/DecisionRepository.java
@@ -1,0 +1,7 @@
+package com.codiapp.codi.domain.meeting.repository;
+
+import com.codiapp.codi.domain.meeting.entity.Decision;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DecisionRepository extends JpaRepository<Decision, Long> {
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/repository/MeetingRepository.java
@@ -1,0 +1,8 @@
+package com.codiapp.codi.domain.meeting.repository;
+
+import com.codiapp.codi.domain.meeting.entity.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+}
+

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandService.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandService.java
@@ -1,0 +1,11 @@
+package com.codiapp.codi.domain.meeting.service;
+
+import com.codiapp.codi.domain.meeting.dto.request.MeetingCreateRequestDTO;
+import com.codiapp.codi.domain.meeting.dto.request.MeetingUpdateRequestDTO;
+import com.codiapp.codi.domain.meeting.entity.Meeting;
+
+public interface MeetingCommandService {
+    Meeting createMeeting(MeetingCreateRequestDTO request);
+    Meeting updateMeeting(Long meetingId, MeetingUpdateRequestDTO request);
+    void deleteMeeting(Long meetingId);
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -3,6 +3,9 @@ package com.codiapp.codi.domain.meeting.service;
 import com.codiapp.codi.domain.meeting.converter.MeetingConverter;
 import com.codiapp.codi.domain.meeting.dto.request.MeetingCreateRequestDTO;
 import com.codiapp.codi.domain.meeting.dto.request.MeetingUpdateRequestDTO;
+import com.codiapp.codi.domain.meeting.entity.Agenda;
+import com.codiapp.codi.domain.meeting.entity.AgendaDetail;
+import com.codiapp.codi.domain.meeting.entity.Decision;
 import com.codiapp.codi.domain.meeting.entity.Meeting;
 import com.codiapp.codi.domain.meeting.repository.MeetingRepository;
 import com.codiapp.codi.domain.team.entity.Team;
@@ -36,7 +39,29 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
 
+        // 기본 정보 수정
         meeting.update(request.title(), request.dateTime(), request.location());
+
+        // 기존 Agenda, Decision 삭제
+        meeting.getAgendas().clear();
+        meeting.getDecisions().clear();
+
+        // 새로운 Agenda 추가
+        request.agendas().forEach(agendaDTO -> {
+            Agenda agenda = Agenda.builder().title(agendaDTO.title()).build();
+            agendaDTO.details().forEach(detailContent -> {
+                AgendaDetail detail = AgendaDetail.builder().content(detailContent).build();
+                agenda.addDetail(detail);
+            });
+            meeting.addAgenda(agenda);
+        });
+
+        // 새로운 Decision 추가
+        request.decisions().forEach(content -> {
+            Decision decision = Decision.builder().content(content).build();
+            meeting.addDecision(decision);
+        });
+
         return meeting;
     }
 

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -1,0 +1,50 @@
+package com.codiapp.codi.domain.meeting.service;
+
+import com.codiapp.codi.domain.meeting.converter.MeetingConverter;
+import com.codiapp.codi.domain.meeting.dto.request.MeetingCreateRequestDTO;
+import com.codiapp.codi.domain.meeting.dto.request.MeetingUpdateRequestDTO;
+import com.codiapp.codi.domain.meeting.entity.Meeting;
+import com.codiapp.codi.domain.meeting.repository.MeetingRepository;
+import com.codiapp.codi.domain.team.entity.Team;
+import com.codiapp.codi.domain.team.repository.TeamRepository;
+import com.codiapp.codi.global.apiPayload.code.status.ErrorStatus;
+import com.codiapp.codi.global.apiPayload.exception.handler.MeetingHandler;
+import com.codiapp.codi.global.apiPayload.exception.handler.TeamHandler;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingCommandServiceImpl implements MeetingCommandService {
+
+    private final MeetingRepository meetingRepository;
+    private final TeamRepository teamRepository;
+
+    @Override
+    public Meeting createMeeting(MeetingCreateRequestDTO request) {
+        Team team = teamRepository.findById(request.teamId())
+                .orElseThrow(() -> new TeamHandler(ErrorStatus.TEAM_NOT_FOUND));
+
+        Meeting meeting = MeetingConverter.toMeeting(request, team);
+        return meetingRepository.save(meeting);
+    }
+
+    @Override
+    @Transactional
+    public Meeting updateMeeting(Long meetingId, MeetingUpdateRequestDTO request) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
+
+        meeting.update(request.title(), request.dateTime(), request.location());
+        return meeting;
+    }
+
+    @Override
+    public void deleteMeeting(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
+
+        meetingRepository.delete(meeting);
+    }
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryService.java
@@ -1,0 +1,7 @@
+package com.codiapp.codi.domain.meeting.service;
+
+import com.codiapp.codi.domain.meeting.dto.response.MeetingDetailResponseDTO;
+
+public interface MeetingQueryService {
+    MeetingDetailResponseDTO getMeetingDetail(Long meetingId);
+}

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.codiapp.codi.domain.meeting.service;
+
+import com.codiapp.codi.domain.meeting.converter.MeetingConverter;
+import com.codiapp.codi.domain.meeting.dto.response.MeetingDetailResponseDTO;
+import com.codiapp.codi.domain.meeting.entity.Meeting;
+import com.codiapp.codi.domain.meeting.repository.MeetingRepository;
+import com.codiapp.codi.global.apiPayload.code.status.ErrorStatus;
+import com.codiapp.codi.global.apiPayload.exception.handler.MeetingHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingQueryServiceImpl implements MeetingQueryService {
+
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    public MeetingDetailResponseDTO getMeetingDetail(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
+
+        return MeetingConverter.toMeetingDetailResponseDTO(meeting);
+    }
+}
+

--- a/src/main/java/com/codiapp/codi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiapp/codi/global/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,9 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.BAD_REQUEST, "SCHEDULE4001", "존재하지 않는 스케줄입니다."),
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "TEAM4001", "존재하지 않는 팀입니다."),
+
+    // 회의록 관련 에러
+    MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEETING4001", "회의록이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/codiapp/codi/global/apiPayload/exception/handler/MeetingHandler.java
+++ b/src/main/java/com/codiapp/codi/global/apiPayload/exception/handler/MeetingHandler.java
@@ -1,0 +1,8 @@
+package com.codiapp.codi.global.apiPayload.exception.handler;
+
+import com.codiapp.codi.global.apiPayload.code.BaseErrorCode;
+import com.codiapp.codi.global.apiPayload.exception.GeneralException;
+
+public class MeetingHandler extends GeneralException {
+    public MeetingHandler(BaseErrorCode errorCode) { super(errorCode); }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #6

## 📝 작업 내용
-   회의록 생성 및 단일 정보 조회와 삭제 구현

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
수정은 db 여러 개가 관계 영향을 좀 더 살펴봐야하는 상황입니다.
그리고 기존에 작성했던 과제에 적힌 sql문은 mysql기준으로 실행돼서 오라클에 맞게 수정해야하는 내용이 있습니다
1)자동생성 -> 시퀀스로 대체
2)text 사용 불가