### PR TITLE
Feat: [Meeting] CRUD 로그인 연동

### DIFF
--- a/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
@@ -45,12 +45,15 @@ public class MeetingController {
     }
     @PatchMapping("/{meetingId}")
     @Operation(summary = "회의록 단일 수정", description = "회의록 ID를 이용해 회의록 상세 내용을 수정합니다.")
-    public ResponseEntity<ApiResponse<Meeting>> updateMeeting(
+    public ResponseEntity<ApiResponse<MeetingDetailResponseDTO>> updateMeeting(
             @PathVariable Long meetingId,
             @RequestBody MeetingUpdateRequestDTO request
     ) {
         Meeting updated = meetingCommandService.updateMeeting(meetingId, request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(updated));
+        // Meeting -> DTO 변환 (조회 로직 재사용)
+        MeetingDetailResponseDTO dto = meetingQueryService.getMeetingDetail(updated.getId());
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(dto));
     }
     @DeleteMapping("/{meetingId}")
     @Operation(summary = "회의록 단일 삭제", description = "회의록 ID를 이용해 회의록 상세 내용을 삭제합니다.")

--- a/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/controller/MeetingController.java
@@ -61,11 +61,12 @@ public class MeetingController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<MeetingListResponseDTO>>> getMeetingList(
+            @RequestParam Long teamId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("dateTime").descending());
-        Page<MeetingListResponseDTO> result = meetingQueryService.getMeetingList(pageable);
+        Page<MeetingListResponseDTO> result = meetingQueryService.getMeetingList(teamId, pageable);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }

--- a/src/main/java/com/codiapp/codi/domain/meeting/dto/request/MeetingUpdateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/dto/request/MeetingUpdateRequestDTO.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 public record MeetingUpdateRequestDTO(
-        Optional<String> title,
-        Optional<LocalDateTime> dateTime,
-        Optional<String> location
+        String title,
+        String dateTime,
+        String location
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/repository/MeetingRepository.java
@@ -1,8 +1,10 @@
 package com.codiapp.codi.domain.meeting.repository;
 
 import com.codiapp.codi.domain.meeting.entity.Meeting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    Page<Meeting> findAllByTeamId(Long teamId, Pageable pageable);
 }
-

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -17,6 +17,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
 @Service
 @RequiredArgsConstructor
 public class MeetingCommandServiceImpl implements MeetingCommandService {
@@ -38,9 +41,19 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
 
-        request.title().ifPresent(meeting::setTitle);
-        request.dateTime().ifPresent(meeting::setDateTime);
-        request.location().ifPresent(meeting::setLocation);
+        if (request.title() != null && !request.title().isBlank()) {
+            meeting.setTitle(request.title());
+        }
+        if (request.dateTime() != null && !request.dateTime().isBlank()) {
+            try {
+                meeting.setDateTime(LocalDateTime.parse(request.dateTime()));
+            } catch (DateTimeParseException e) {
+                throw new MeetingHandler(ErrorStatus.INVALID_DATE_FORMAT); // 예외 커스텀 정의 필요
+            }
+        }
+        if (request.location() != null && !request.location().isBlank()) {
+            meeting.setLocation(request.location());
+        }
 
         return meeting;
     }

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryService.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface MeetingQueryService {
     MeetingDetailResponseDTO getMeetingDetail(Long meetingId);
-    public Page<MeetingListResponseDTO> getMeetingList(Pageable pageable);
+    public Page<MeetingListResponseDTO> getMeetingList(Long teamId,Pageable pageable);
 }

--- a/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -26,8 +26,8 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
     }
 
     @Override
-    public Page<MeetingListResponseDTO> getMeetingList(Pageable pageable) {
-        return meetingRepository.findAll(pageable)
+    public Page<MeetingListResponseDTO> getMeetingList(Long teamId, Pageable pageable) {
+        return meetingRepository.findAllByTeamId(teamId, pageable)
                 .map(MeetingConverter::toMeetingListDTO);
     }
 }

--- a/src/main/java/com/codiapp/codi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/codiapp/codi/global/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 회의록 관련 에러
     MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEETING4001", "회의록이 없습니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "MEETING4002", "잘못된 날짜 형식입니다."),
 
 
     //로그인 관련 에러


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #32

## 📝 작업 내용
-  기존에 로그인 구현전에 진행돼서 하드코딩됐던 teamID 인식을 로그인한 유저의 정보를 통해 인식하도록 수정 
- 프론트엔드와 연동 과정중 update기능 기본 엔티티반환에서 dto로 변경해 직렬화 문제 해결 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
