### PR TITLE
Feat: [task guide] 프론트 연동 리스트 조회, 정렬추가

### DIFF
--- a/src/main/java/com/codiapp/codi/domain/taskGuide/controller/TaskGuideController.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/controller/TaskGuideController.java
@@ -2,11 +2,15 @@ package com.codiapp.codi.domain.taskGuide.controller;
 
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideCreateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideUpdateRequestDTO;
+import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideListResponseDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideResponseDTO;
 import com.codiapp.codi.domain.taskGuide.service.TaskGuideCommandService;
 import com.codiapp.codi.domain.taskGuide.service.TaskGuideQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,6 +34,17 @@ public class TaskGuideController {
     @Operation(summary = "단일 과제 제공 조회")
     public ResponseEntity<TaskGuideResponseDTO> getTaskGuide(@PathVariable Long id) {
         TaskGuideResponseDTO response = taskGuideQueryService.getTaskGuide(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 과제제공 리스트 조회")
+    public ResponseEntity<Page<TaskGuideListResponseDTO>> getAllTaskGuides(
+            @RequestParam Long courseId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<TaskGuideListResponseDTO> response = taskGuideQueryService.getAllTaskGuides(courseId, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/converter/TaskGuideConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/converter/TaskGuideConverter.java
@@ -3,6 +3,7 @@ package com.codiapp.codi.domain.taskGuide.converter;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideCreateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideDetailCreateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideDetailResponseDTO;
+import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideListResponseDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideResponseDTO;
 import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
 import com.codiapp.codi.domain.taskGuide.entity.TaskGuideDetail;
@@ -46,5 +47,14 @@ public class TaskGuideConverter {
                 .description(request.description())
                 .taskGuide(taskGuide)
                 .build();
+    }
+
+    public static TaskGuideListResponseDTO taskGuideListResponseDTO(TaskGuide taskGuide) {
+        return new TaskGuideListResponseDTO(
+                taskGuide.getId(),
+                taskGuide.getTitle(),
+                taskGuide.getDueDate(),
+                taskGuide.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/dto/response/TaskGuideListResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/dto/response/TaskGuideListResponseDTO.java
@@ -1,0 +1,10 @@
+package com.codiapp.codi.domain.taskGuide.dto.response;
+
+import java.time.LocalDateTime;
+
+public record TaskGuideListResponseDTO(
+        Long id,
+        String title,
+        LocalDateTime dueDate,
+        LocalDateTime createAt
+) {}

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/entity/TaskGuide.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/entity/TaskGuide.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +47,7 @@ public class TaskGuide {
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "taskGuide", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id ASC")
     private List<TaskGuideDetail> details = new ArrayList<>();
 
     public void updateTitle(String title) {

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/repository/TaskGuideRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/repository/TaskGuideRepository.java
@@ -1,7 +1,10 @@
 package com.codiapp.codi.domain.taskGuide.repository;
 
 import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TaskGuideRepository extends JpaRepository<TaskGuide, Long> {
+    Page<TaskGuide> findAllByCourseId(Long courseId, Pageable pageable);
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryService.java
@@ -1,7 +1,11 @@
 package com.codiapp.codi.domain.taskGuide.service;
 
+import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideListResponseDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TaskGuideQueryService {
     TaskGuideResponseDTO getTaskGuide(Long id);
+    Page<TaskGuideListResponseDTO> getAllTaskGuides(Long courseId, Pageable pageable);
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryServiceImpl.java
@@ -1,11 +1,14 @@
 package com.codiapp.codi.domain.taskGuide.service;
 
 import com.codiapp.codi.domain.taskGuide.converter.TaskGuideConverter;
+import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideListResponseDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideResponseDTO;
 import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
 import com.codiapp.codi.domain.taskGuide.repository.TaskGuideRepository;
 import com.codiapp.codi.global.apiPayload.exception.handler.TaskGuideHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import static com.codiapp.codi.global.apiPayload.code.status.ErrorStatus.TaskGuide_NOT_FOUND;
@@ -20,5 +23,11 @@ public class TaskGuideQueryServiceImpl implements TaskGuideQueryService {
         TaskGuide taskGuide = taskGuideRepository.findById(id)
                 .orElseThrow(() -> new TaskGuideHandler(TaskGuide_NOT_FOUND));
         return TaskGuideConverter.toTaskGuideResponeDTO(taskGuide);
+    }
+
+    @Override
+    public Page<TaskGuideListResponseDTO> getAllTaskGuides(Long courseId, Pageable pageable) {
+        return taskGuideRepository.findAllByCourseId(courseId, pageable)
+                .map(TaskGuideConverter::taskGuideListResponseDTO);
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #45 

## 📝 작업 내용
- 프론트를 연동하는 과정에서 필요한 제공 리스트 조회 기능을 추가했습니다. 
- detail 수정상황에서 정렬이 바뀌는 문제가 있어 엔티티에 정렬 추가했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
기본 연결을 위주로 해서 교수자 권한이나 courseId에 대한 부분은 마지막에 할 예정입니다. 
taskGuide로 이름을 수정했습니다.