### PR TITLE
Feat: [task guide] 학생 task와 연결

### DIFF
--- a/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
+++ b/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
@@ -92,11 +92,17 @@ public class TaskController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/teamList")
-    public ApiResponse<List<FinalTeamListResponseDTO>> getTeamTasksByStatus(
+    @GetMapping("/teamTasks")
+    public ResponseEntity<ApiResponse<Page<FinalTeamListResponseDTO>>> getTeamTasksByStatus(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam Long courseId,
             @RequestParam Long teamId,
-            @RequestParam TaskStatus status) {
-        return ApiResponse.onSuccess(taskQueryService.getTeamTasksByStatus(courseId, teamId, status));
+            @RequestParam TaskStatus status
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FinalTeamListResponseDTO> response =
+                taskQueryService.getTeamTasksByStatus(courseId, teamId, status, pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
+++ b/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
@@ -5,8 +5,10 @@ import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
+import com.codiapp.codi.domain.task.dto.response.FinalTeamListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
+import com.codiapp.codi.domain.task.entity.TaskStatus;
 import com.codiapp.codi.domain.task.service.TaskCommandService;
 import com.codiapp.codi.domain.task.service.TaskQueryService;
 import com.codiapp.codi.global.apiPayload.ApiResponse;
@@ -17,6 +19,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -88,4 +92,11 @@ public class TaskController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/teamList")
+    public ApiResponse<List<FinalTeamListResponseDTO>> getTeamTasksByStatus(
+            @RequestParam Long courseId,
+            @RequestParam Long teamId,
+            @RequestParam TaskStatus status) {
+        return ApiResponse.onSuccess(taskQueryService.getTeamTasksByStatus(courseId, teamId, status));
+    }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
+++ b/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
@@ -2,10 +2,12 @@ package com.codiapp.codi.domain.task.controller;
 
 import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
+import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
 import com.codiapp.codi.domain.task.service.TaskCommandService;
 import com.codiapp.codi.domain.task.service.TaskQueryService;
+import com.codiapp.codi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,7 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/tasks")
@@ -61,5 +62,10 @@ public class TaskController {
     public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
         taskCommandService.deleteTask(taskId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/final/{taskId}")
+    public ApiResponse<FinalTaskResponseDTO> getFinalTask(@PathVariable Long taskId) {
+        return ApiResponse.onSuccess(taskQueryService.getFinalTask(taskId));
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
+++ b/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.task.controller;
 
+import com.codiapp.codi.domain.task.dto.request.FinalTaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
@@ -65,7 +66,19 @@ public class TaskController {
     }
 
     @GetMapping("/final/{taskId}")
+    @Operation(summary = "최종 과제 조회")
     public ApiResponse<FinalTaskResponseDTO> getFinalTask(@PathVariable Long taskId) {
         return ApiResponse.onSuccess(taskQueryService.getFinalTask(taskId));
     }
+
+    @PatchMapping("/final/{taskId}")
+    @Operation(summary = "최종 과제 수정")
+    public ApiResponse<Void> updateFinalTask(
+            @PathVariable Long taskId,
+            @RequestBody FinalTaskUpdateRequestDTO dto
+    ) {
+        taskCommandService.updateFinalTask(taskId, dto);
+        return ApiResponse.onSuccess(null);
+    }
+
 }

--- a/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
+++ b/src/main/java/com/codiapp/codi/domain/task/controller/TaskController.java
@@ -3,6 +3,7 @@ package com.codiapp.codi.domain.task.controller;
 import com.codiapp.codi.domain.task.dto.request.FinalTaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
+import com.codiapp.codi.domain.task.dto.response.FinalTaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
@@ -41,13 +42,13 @@ public class TaskController {
     }
 
     @GetMapping
-    @Operation(summary = "전체 과제 리스트 조회")
-    public ResponseEntity<Page<TaskListResponseDTO>> getAllTasks(
+    @Operation(summary = "최종 전체 과제 리스트 조회")
+    public ResponseEntity<Page<FinalTaskListResponseDTO>> getAllTasks(
             @RequestParam Long teamId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<TaskListResponseDTO> response = taskQueryService.getAllTasks(teamId, pageable);
+        Page<FinalTaskListResponseDTO> response = taskQueryService.getAllTasks(teamId, pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -79,6 +80,12 @@ public class TaskController {
     ) {
         taskCommandService.updateFinalTask(taskId, dto);
         return ApiResponse.onSuccess(null);
+    }
+
+    @PatchMapping("/{taskId}/status")
+    public ResponseEntity<Void> toggleTaskStatus(@PathVariable Long taskId) {
+        taskCommandService.toggleTaskStatus(taskId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
@@ -100,6 +100,8 @@ public class TaskConverter {
                 task.getId(),
                 task.getStatus(),
                 task.getTaskDate(),
+                task.getTaskGuide().getId(),
+                task.getTaskGuide().getTitle(),
                 task.getTeam().getId(),
                 task.getTeam().getCourse().getId()
         );

--- a/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
@@ -94,4 +94,14 @@ public class TaskConverter {
             }
         }
     }
+
+    public static FinalTeamListResponseDTO toFinalTeamListResponseDTO(Task task) {
+        return new FinalTeamListResponseDTO(
+                task.getId(),
+                task.getStatus(),
+                task.getTaskDate(),
+                task.getTeam().getId(),
+                task.getTeam().getCourse().getId()
+        );
+    }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
@@ -48,6 +48,17 @@ public class TaskConverter {
         );
     }
 
+    public static FinalTaskListResponseDTO toFinalTaskListResponseDTO (Task task) {
+        return new FinalTaskListResponseDTO(
+                task.getId(),
+                task.getStatus(),
+                task.getTaskGuide().getId(),
+                task.getTaskGuide().getTitle(),
+                task.getTaskGuide().getDueDate(),
+                task.getTaskGuide().getCreatedAt()
+        );
+    }
+
 
     // Task Entity → TaskResponseDTO (단건 상세)
     public static TaskResponseDTO toTaskResponseDTO(Task task) {

--- a/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
@@ -6,6 +6,7 @@ import com.codiapp.codi.domain.task.entity.*;
 import com.codiapp.codi.domain.team.entity.Team;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class TaskConverter {
@@ -20,6 +21,7 @@ public class TaskConverter {
         return task;
     }
 
+    //final 단일 조회
     public static FinalTaskResponseDTO toFinalTaskResponseDTO(Task task) {
         List<FinalDetailResponseDTO> detailDTOs = task.getDetails().stream()
                 .map(detail -> {
@@ -68,5 +70,17 @@ public class TaskConverter {
                 task.getStatus(),
                 task.getTaskDate()
         );
+    }
+
+    //final 기능에서 update
+    public static void applyFinalTaskUpdate(Task task, FinalTaskUpdateRequestDTO dto) {
+        Map<Long, String> contentMap = dto.details().stream()
+                .collect(Collectors.toMap(FinalDetailUpdateRequestDTO::taskDetailId, FinalDetailUpdateRequestDTO::content));
+
+        for (TaskDetail detail : task.getDetails()) {
+            if (contentMap.containsKey(detail.getId())) {
+                detail.updateContent(contentMap.get(detail.getId()));
+            }
+        }
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/task/converter/TaskConverter.java
@@ -13,7 +13,6 @@ public class TaskConverter {
     // Create DTO → Task Entity
     public static Task toTask(TaskCreateRequestDTO request, Team team) {
         Task task = Task.builder()
-                .title(request.title())
                 .status(request.status())
                 .taskDate(request.taskDate())
                 .team(team)
@@ -21,15 +20,41 @@ public class TaskConverter {
         return task;
     }
 
+    public static FinalTaskResponseDTO toFinalTaskResponseDTO(Task task) {
+        List<FinalDetailResponseDTO> detailDTOs = task.getDetails().stream()
+                .map(detail -> {
+                    var guideDetail = detail.getTaskGuideDetail();
+                    return new FinalDetailResponseDTO(
+                            detail.getId(),
+                            detail.getContent(),
+                            guideDetail.getId(),
+                            guideDetail.getTitle(),
+                            guideDetail.getDescription()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new FinalTaskResponseDTO(
+                task.getId(),
+                task.getTeam().getName(),
+                task.getTaskDate(),
+                task.getTaskGuide().getId(),
+                task.getTaskGuide().getTitle(),
+                task.getTaskGuide().getDueDate(),
+                task.getTaskGuide().getCreatedAt(),
+                detailDTOs
+        );
+    }
+
+
     // Task Entity → TaskResponseDTO (단건 상세)
     public static TaskResponseDTO toTaskResponseDTO(Task task) {
         List<TaskDetailResponseDTO> detailDTOs = task.getDetails().stream()
-                .map(d -> new TaskDetailResponseDTO(d.getId(), d.getTitle(), d.getContent()))
+                .map(d -> new TaskDetailResponseDTO(d.getId(), d.getContent()))
                 .collect(Collectors.toList());
 
         return new TaskResponseDTO(
                 task.getId(),
-                task.getTitle(),
                 task.getStatus(),
                 task.getTaskDate(),
                 detailDTOs
@@ -40,7 +65,6 @@ public class TaskConverter {
     public static TaskListResponseDTO toTaskListResponseDTO(Task task) {
         return new TaskListResponseDTO(
                 task.getId(),
-                task.getTitle(),
                 task.getStatus(),
                 task.getTaskDate()
         );

--- a/src/main/java/com/codiapp/codi/domain/task/dto/request/FinalDetailUpdateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/request/FinalDetailUpdateRequestDTO.java
@@ -1,0 +1,6 @@
+package com.codiapp.codi.domain.task.dto.request;
+
+public record FinalDetailUpdateRequestDTO(
+        Long taskDetailId,
+        String content
+) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/request/FinalTaskUpdateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/request/FinalTaskUpdateRequestDTO.java
@@ -1,0 +1,7 @@
+package com.codiapp.codi.domain.task.dto.request;
+
+import java.util.List;
+
+public record FinalTaskUpdateRequestDTO(
+        List<FinalDetailUpdateRequestDTO> details
+) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskCreateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskCreateRequestDTO.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 public record TaskCreateRequestDTO(
         Long teamId,
-        String title,
         TaskStatus status,
         LocalDate taskDate
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskDetailCreateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskDetailCreateRequestDTO.java
@@ -2,6 +2,5 @@ package com.codiapp.codi.domain.task.dto.request;
 
 public record TaskDetailCreateRequestDTO(
         Long taskId,
-        String title,
         String content
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskDetailUpdateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskDetailUpdateRequestDTO.java
@@ -3,6 +3,5 @@ package com.codiapp.codi.domain.task.dto.request;
 import java.util.Optional;
 
 public record TaskDetailUpdateRequestDTO(
-        Optional<String> title,
         Optional<String> content
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskUpdateRequestDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/request/TaskUpdateRequestDTO.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 public record TaskUpdateRequestDTO(
-        Optional<String> title,
         Optional<TaskStatus> status,
         Optional<LocalDate> taskDate
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalDetailResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalDetailResponseDTO.java
@@ -1,0 +1,12 @@
+package com.codiapp.codi.domain.task.dto.response;
+
+public record FinalDetailResponseDTO(
+        //taskDetail
+        Long taskDetailId,
+        String content,
+        //taskGuideDetail
+        Long taskGuideDetailId,
+        String title,
+        String description
+
+) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTaskListResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTaskListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.codiapp.codi.domain.task.dto.response;
+
+import com.codiapp.codi.domain.task.entity.TaskStatus;
+
+import java.time.LocalDateTime;
+
+public record FinalTaskListResponseDTO(
+        Long taskId,
+        TaskStatus status,
+        Long taskGuideId,
+        String title,
+        LocalDateTime dueDate,
+        LocalDateTime createAt
+) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTaskResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTaskResponseDTO.java
@@ -1,0 +1,17 @@
+package com.codiapp.codi.domain.task.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FinalTaskResponseDTO(
+   Long taskId,
+   String teamName,
+   LocalDate taskDate,
+
+   Long taskGuideId,
+   String title,
+   LocalDateTime dueDate,
+   LocalDateTime createAt,
+   List<FinalDetailResponseDTO> details
+) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTeamListResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTeamListResponseDTO.java
@@ -8,6 +8,8 @@ public record FinalTeamListResponseDTO(
         Long taskId,
         TaskStatus status,
         LocalDate taskDate,
+        Long taskGuideId,
+        String title,
         Long teamId,
         Long courseId
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTeamListResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/FinalTeamListResponseDTO.java
@@ -1,0 +1,13 @@
+package com.codiapp.codi.domain.task.dto.response;
+
+import com.codiapp.codi.domain.task.entity.TaskStatus;
+
+import java.time.LocalDate;
+
+public record FinalTeamListResponseDTO(
+        Long taskId,
+        TaskStatus status,
+        LocalDate taskDate,
+        Long teamId,
+        Long courseId
+) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/TaskDetailResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/TaskDetailResponseDTO.java
@@ -2,6 +2,5 @@ package com.codiapp.codi.domain.task.dto.response;
 
 public record TaskDetailResponseDTO(
         Long id,
-        String title,
         String content
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/TaskListResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/TaskListResponseDTO.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 
 public record TaskListResponseDTO(
         Long id,
-        String title,
         TaskStatus status,
         LocalDate taskDate
 ) {}

--- a/src/main/java/com/codiapp/codi/domain/task/dto/response/TaskResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/task/dto/response/TaskResponseDTO.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 public record TaskResponseDTO(
         Long id,
-        String title,
         TaskStatus status,
         LocalDate taskDate,
         List<TaskDetailResponseDTO> details

--- a/src/main/java/com/codiapp/codi/domain/task/entity/Task.java
+++ b/src/main/java/com/codiapp/codi/domain/task/entity/Task.java
@@ -1,6 +1,7 @@
 package com.codiapp.codi.domain.task.entity;
 
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
+import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
 import com.codiapp.codi.domain.team.entity.Team;
 import jakarta.persistence.*;
 import lombok.*;
@@ -24,8 +25,6 @@ public class Task {
     @JoinColumn(name = "team_id")
     private Team team;
 
-    private String title;
-
     @Enumerated(EnumType.STRING)
     private TaskStatus status;
 
@@ -35,14 +34,9 @@ public class Task {
     @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TaskDetail> details = new ArrayList<>();
 
-    public void addDetail(TaskDetail detail) {
-        details.add(detail);
-        detail.setTask(this);
-    }
-
-    public void updateTitle(String title) {
-        this.title = title;
-    }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "taskGuide_id")
+    private TaskGuide taskGuide;
 
     public void updateStatus(TaskStatus status) {
         this.status = status;
@@ -53,7 +47,6 @@ public class Task {
     }
 
     public void applyUpdate(TaskUpdateRequestDTO request) {
-        request.title().ifPresent(this::updateTitle);
         request.status().ifPresent(this::updateStatus);
         request.taskDate().ifPresent(this::updateTaskDate);
     }

--- a/src/main/java/com/codiapp/codi/domain/task/entity/TaskDetail.java
+++ b/src/main/java/com/codiapp/codi/domain/task/entity/TaskDetail.java
@@ -1,5 +1,7 @@
 package com.codiapp.codi.domain.task.entity;
 
+import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
+import com.codiapp.codi.domain.taskGuide.entity.TaskGuideDetail;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -26,8 +28,6 @@ public class TaskDetail {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
-
     @Lob
     private String content;
 
@@ -35,12 +35,12 @@ public class TaskDetail {
     @JoinColumn(name = "task_id")
     private Task task;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "taskGuideDetail_id")
+    private TaskGuideDetail taskGuideDetail;
+
     public void setTask(Task task) {
         this.task = task;
-    }
-
-    public void updateTitle(String title) {
-        this.title = title;
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/codiapp/codi/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/task/repository/TaskRepository.java
@@ -12,6 +12,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     // 특정 팀(teamId)에 속한 모든 Task 목록 조회
     Page<Task> findAllByTeamId(Long teamId, Pageable pageable);
-    List<Task> findByTeam_Course_IdAndTeam_IdAndStatus(Long courseId, Long teamId, TaskStatus status);
+    Page<Task> findByTaskGuide_Course_IdAndTeamIdAndStatus(Long courseId, Long teamId, TaskStatus status, Pageable pageable);
 
 }

--- a/src/main/java/com/codiapp/codi/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/task/repository/TaskRepository.java
@@ -1,6 +1,7 @@
 package com.codiapp.codi.domain.task.repository;
 
 import com.codiapp.codi.domain.task.entity.Task;
+import com.codiapp.codi.domain.task.entity.TaskStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     // 특정 팀(teamId)에 속한 모든 Task 목록 조회
     Page<Task> findAllByTeamId(Long teamId, Pageable pageable);
+    List<Task> findByTeam_Course_IdAndTeam_IdAndStatus(Long courseId, Long teamId, TaskStatus status);
+
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandService.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.task.service;
 
+import com.codiapp.codi.domain.task.dto.request.FinalTaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
 
@@ -7,4 +8,5 @@ public interface TaskCommandService {
     Long createTask(TaskCreateRequestDTO request);
     void updateTask(Long taskId, TaskUpdateRequestDTO request);
     void deleteTask(Long taskId);
+    void updateFinalTask(Long taskId, FinalTaskUpdateRequestDTO dto);
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandService.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandService.java
@@ -9,4 +9,5 @@ public interface TaskCommandService {
     void updateTask(Long taskId, TaskUpdateRequestDTO request);
     void deleteTask(Long taskId);
     void updateFinalTask(Long taskId, FinalTaskUpdateRequestDTO dto);
+    void toggleTaskStatus(Long taskId);
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package com.codiapp.codi.domain.task.service;
 
 import com.codiapp.codi.domain.task.converter.TaskConverter;
+import com.codiapp.codi.domain.task.dto.request.FinalTaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.entity.Task;
@@ -45,5 +46,15 @@ public class TaskCommandServiceImpl implements TaskCommandService {
                 .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_NOT_FOUND));
 
         taskRepository.delete(task);
+    }
+
+    @Override
+    @Transactional
+    public void updateFinalTask(Long taskId, FinalTaskUpdateRequestDTO dto) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_NOT_FOUND));
+
+        TaskConverter.applyFinalTaskUpdate(task, dto);
+        // dirty checking으로 자동 저장됨
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.codiapp.codi.domain.task.dto.request.FinalTaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskCreateRequestDTO;
 import com.codiapp.codi.domain.task.dto.request.TaskUpdateRequestDTO;
 import com.codiapp.codi.domain.task.entity.Task;
+import com.codiapp.codi.domain.task.entity.TaskStatus;
 import com.codiapp.codi.domain.task.repository.TaskRepository;
 import com.codiapp.codi.domain.team.entity.Team;
 import com.codiapp.codi.domain.team.repository.TeamRepository;
@@ -14,6 +15,8 @@ import com.codiapp.codi.global.apiPayload.exception.handler.TeamHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -56,5 +59,21 @@ public class TaskCommandServiceImpl implements TaskCommandService {
 
         TaskConverter.applyFinalTaskUpdate(task, dto);
         // dirty checking으로 자동 저장됨
+    }
+
+    @Override
+    @Transactional
+    public void toggleTaskStatus(Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_NOT_FOUND));
+
+        // 상태 토글
+        if (task.getStatus() == TaskStatus.IN_PROGRESS) {
+            task.updateStatus(TaskStatus.COMPLETE);
+            task.updateTaskDate(LocalDate.now());
+        } else {
+            task.updateStatus(TaskStatus.IN_PROGRESS);
+            task.updateTaskDate(null);
+        }
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskDetailCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskDetailCommandServiceImpl.java
@@ -25,7 +25,6 @@ public class TaskDetailCommandServiceImpl implements TaskDetailCommandService {
                 .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_NOT_FOUND));
 
         TaskDetail detail = TaskDetail.builder()
-                .title(request.title())
                 .content(request.content())
                 .task(task)
                 .build();
@@ -38,8 +37,6 @@ public class TaskDetailCommandServiceImpl implements TaskDetailCommandService {
     public void updateDetail(Long detailId, TaskDetailUpdateRequestDTO request) {
         TaskDetail detail = taskDetailRepository.findById(detailId)
                 .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_DETAIL_NOT_FOUND));
-
-        request.title().ifPresent(detail::updateTitle);
         request.content().ifPresent(detail::updateContent);
     }
 

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
@@ -15,6 +15,6 @@ public interface TaskQueryService {
     TaskResponseDTO getTask(Long taskId);
     Page<FinalTaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable);
     FinalTaskResponseDTO getFinalTask(Long taskId);
-    List<FinalTeamListResponseDTO> getTeamTasksByStatus(Long courseId, Long teamId, TaskStatus status);
+    Page<FinalTeamListResponseDTO> getTeamTasksByStatus(Long courseId, Long teamId, TaskStatus status, Pageable pageable);
 
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.task.service;
 
+import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
 import org.springframework.data.domain.Page;
@@ -10,4 +11,5 @@ import java.util.List;
 public interface TaskQueryService {
     TaskResponseDTO getTask(Long taskId);
     Page<TaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable);
+    FinalTaskResponseDTO getFinalTask(Long taskId);
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
@@ -2,8 +2,10 @@ package com.codiapp.codi.domain.task.service;
 
 import com.codiapp.codi.domain.task.dto.response.FinalTaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
+import com.codiapp.codi.domain.task.dto.response.FinalTeamListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
+import com.codiapp.codi.domain.task.entity.TaskStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,5 +15,6 @@ public interface TaskQueryService {
     TaskResponseDTO getTask(Long taskId);
     Page<FinalTaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable);
     FinalTaskResponseDTO getFinalTask(Long taskId);
+    List<FinalTeamListResponseDTO> getTeamTasksByStatus(Long courseId, Long teamId, TaskStatus status);
 
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryService.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.task.service;
 
+import com.codiapp.codi.domain.task.dto.response.FinalTaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
@@ -10,6 +11,7 @@ import java.util.List;
 
 public interface TaskQueryService {
     TaskResponseDTO getTask(Long taskId);
-    Page<TaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable);
+    Page<FinalTaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable);
     FinalTaskResponseDTO getFinalTask(Long taskId);
+
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.codiapp.codi.domain.task.service;
 
 import com.codiapp.codi.domain.task.converter.TaskConverter;
+import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
 import com.codiapp.codi.domain.task.repository.TaskRepository;
@@ -32,5 +33,12 @@ public class TaskQueryServiceImpl implements TaskQueryService {
     public Page<TaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable) {
         return taskRepository.findAllByTeamId(teamId, pageable)
                 .map(TaskConverter::toTaskListResponseDTO);
+    }
+
+    @Override
+    public FinalTaskResponseDTO getFinalTask(Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_NOT_FOUND));
+        return TaskConverter.toFinalTaskResponseDTO(task);
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
@@ -46,10 +46,8 @@ public class TaskQueryServiceImpl implements TaskQueryService {
     }
 
     @Override
-    public List<FinalTeamListResponseDTO> getTeamTasksByStatus(Long courseId, Long teamId, TaskStatus status) {
-        return taskRepository.findByTeam_Course_IdAndTeam_IdAndStatus(courseId, teamId, status)
-                .stream()
-                .map(TaskConverter::toFinalTeamListResponseDTO)
-                .toList();
+    public Page<FinalTeamListResponseDTO> getTeamTasksByStatus(Long courseId, Long teamId, TaskStatus status, Pageable pageable) {
+        return taskRepository.findByTaskGuide_Course_IdAndTeamIdAndStatus(courseId, teamId, status, pageable)
+                .map(TaskConverter::toFinalTeamListResponseDTO);
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
@@ -3,8 +3,10 @@ package com.codiapp.codi.domain.task.service;
 import com.codiapp.codi.domain.task.converter.TaskConverter;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
+import com.codiapp.codi.domain.task.dto.response.FinalTeamListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
+import com.codiapp.codi.domain.task.entity.TaskStatus;
 import com.codiapp.codi.domain.task.repository.TaskRepository;
 import com.codiapp.codi.global.apiPayload.code.status.ErrorStatus;
 import com.codiapp.codi.global.apiPayload.exception.handler.TaskHandler;
@@ -41,5 +43,13 @@ public class TaskQueryServiceImpl implements TaskQueryService {
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new TaskHandler(ErrorStatus.TASK_NOT_FOUND));
         return TaskConverter.toFinalTaskResponseDTO(task);
+    }
+
+    @Override
+    public List<FinalTeamListResponseDTO> getTeamTasksByStatus(Long courseId, Long teamId, TaskStatus status) {
+        return taskRepository.findByTeam_Course_IdAndTeam_IdAndStatus(courseId, teamId, status)
+                .stream()
+                .map(TaskConverter::toFinalTeamListResponseDTO)
+                .toList();
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/task/service/TaskQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.codiapp.codi.domain.task.service;
 
 import com.codiapp.codi.domain.task.converter.TaskConverter;
+import com.codiapp.codi.domain.task.dto.response.FinalTaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.FinalTaskResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskListResponseDTO;
 import com.codiapp.codi.domain.task.dto.response.TaskResponseDTO;
@@ -30,9 +31,9 @@ public class TaskQueryServiceImpl implements TaskQueryService {
     }
 
     @Override
-    public Page<TaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable) {
+    public Page<FinalTaskListResponseDTO> getAllTasks(Long teamId, Pageable pageable) {
         return taskRepository.findAllByTeamId(teamId, pageable)
-                .map(TaskConverter::toTaskListResponseDTO);
+                .map(TaskConverter::toFinalTaskListResponseDTO);
     }
 
     @Override

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/controller/TaskGuideController.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/controller/TaskGuideController.java
@@ -4,8 +4,11 @@ import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideCreateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideUpdateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideListResponseDTO;
 import com.codiapp.codi.domain.taskGuide.dto.response.TaskGuideResponseDTO;
+import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
 import com.codiapp.codi.domain.taskGuide.service.TaskGuideCommandService;
 import com.codiapp.codi.domain.taskGuide.service.TaskGuideQueryService;
+import com.codiapp.codi.global.apiPayload.code.status.ErrorStatus;
+import com.codiapp.codi.global.apiPayload.exception.handler.TaskGuideHandler;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -68,4 +71,10 @@ public class TaskGuideController {
         taskGuideCommandService.deleteTaskGuide(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/taskGuide/{id}/generateTasks")
+    public void generateTasks(@PathVariable Long id) {
+        taskGuideCommandService.generateTasks(id);
+    }
+
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/controller/TaskGuideController.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/controller/TaskGuideController.java
@@ -72,7 +72,7 @@ public class TaskGuideController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/taskGuide/{id}/generateTasks")
+    @PostMapping("/{id}/generateTasks")
     public void generateTasks(@PathVariable Long id) {
         taskGuideCommandService.generateTasks(id);
     }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/entity/TaskGuide.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/entity/TaskGuide.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.taskGuide.entity;
 
+import com.codiapp.codi.domain.task.entity.Task;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideUpdateRequestDTO;
 import com.codiapp.codi.domain.course.entity.Course;
 import jakarta.persistence.Column;
@@ -49,6 +50,9 @@ public class TaskGuide {
     @OneToMany(mappedBy = "taskGuide", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("id ASC")
     private List<TaskGuideDetail> details = new ArrayList<>();
+
+    @OneToMany(mappedBy = "taskGuide", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Task> tasks = new ArrayList<>();
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/entity/TaskGuideDetail.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/entity/TaskGuideDetail.java
@@ -1,6 +1,8 @@
 package com.codiapp.codi.domain.taskGuide.entity;
 
+import com.codiapp.codi.domain.task.entity.TaskDetail;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideDetailUpdateRequestDTO;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,12 +10,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +40,9 @@ public class TaskGuideDetail {
     private String title;
 
     private String description;
+
+    @OneToMany(mappedBy = "taskGuideDetail", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TaskDetail> taskDetails = new ArrayList<>();
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideCommandService.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideCommandService.java
@@ -2,9 +2,12 @@ package com.codiapp.codi.domain.taskGuide.service;
 
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideCreateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideUpdateRequestDTO;
+import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
 
 public interface TaskGuideCommandService {
     Long createTaskGuide(TaskGuideCreateRequestDTO request);
     void updateTaskGuide(Long id, TaskGuideUpdateRequestDTO request);
     void deleteTaskGuide(Long id);
+    void createEmptyTasksForTeams(TaskGuide guide);
+    void generateTasks(Long taskGuideId);
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideCommandServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideCommandServiceImpl.java
@@ -1,12 +1,19 @@
 package com.codiapp.codi.domain.taskGuide.service;
 
+import com.codiapp.codi.domain.task.entity.Task;
+import com.codiapp.codi.domain.task.entity.TaskDetail;
+import com.codiapp.codi.domain.task.entity.TaskStatus;
+import com.codiapp.codi.domain.task.repository.TaskRepository;
 import com.codiapp.codi.domain.taskGuide.converter.TaskGuideConverter;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideCreateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.dto.request.TaskGuideUpdateRequestDTO;
 import com.codiapp.codi.domain.taskGuide.entity.TaskGuide;
+import com.codiapp.codi.domain.taskGuide.entity.TaskGuideDetail;
 import com.codiapp.codi.domain.taskGuide.repository.TaskGuideRepository;
 import com.codiapp.codi.domain.course.entity.Course;
 import com.codiapp.codi.domain.course.repository.CourseRepository;
+import com.codiapp.codi.domain.team.entity.Team;
+import com.codiapp.codi.domain.team.repository.TeamRepository;
 import com.codiapp.codi.global.apiPayload.code.status.ErrorStatus;
 import com.codiapp.codi.global.apiPayload.exception.handler.TaskGuideHandler;
 import com.codiapp.codi.global.apiPayload.exception.handler.CourseHandler;
@@ -14,13 +21,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TaskGuideCommandServiceImpl implements TaskGuideCommandService {
 
     private final TaskGuideRepository taskGuideRepository;
     private final CourseRepository courseRepository;
+    private final TeamRepository teamRepository;
+    private final TaskRepository taskRepository;
 
+    @Transactional
     @Override
     public Long createTaskGuide(TaskGuideCreateRequestDTO request) {
         Course course = courseRepository.findById(request.courseId())
@@ -45,5 +57,36 @@ public class TaskGuideCommandServiceImpl implements TaskGuideCommandService {
                 .orElseThrow(()-> new TaskGuideHandler(ErrorStatus.TaskGuide_NOT_FOUND));
 
         taskGuideRepository.delete(taskGuide);
+    }
+
+    @Transactional
+    @Override
+    public void generateTasks(Long taskGuideId) {
+        TaskGuide guide = taskGuideRepository.findById(taskGuideId)
+                .orElseThrow(() -> new TaskGuideHandler(ErrorStatus.TaskGuide_NOT_FOUND));
+        createEmptyTasksForTeams(guide);
+    }
+
+    public void createEmptyTasksForTeams(TaskGuide guide) {
+        List<Team> teams = teamRepository.findAllByCourseId(guide.getCourse().getId());
+
+        for (Team team : teams) {
+            Task task = Task.builder()
+                    .team(team)
+                    .taskGuide(guide)
+                    .status(TaskStatus.IN_PROGRESS) // 처음엔 제출 전 상태
+                    .build();
+
+            for (TaskGuideDetail guideDetail : guide.getDetails()) {
+                TaskDetail detail = TaskDetail.builder()
+                        .task(task)
+                        .taskGuideDetail(guideDetail)
+                        .content("") // 초기엔 빈칸
+                        .build();
+                task.getDetails().add(detail); // 양방향 연관관계 설정
+            }
+
+            taskRepository.save(task); // cascade로 detail도 저장됨
+        }
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryService.java
@@ -8,4 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface TaskGuideQueryService {
     TaskGuideResponseDTO getTaskGuide(Long id);
     Page<TaskGuideListResponseDTO> getAllTaskGuides(Long courseId, Pageable pageable);
+
 }

--- a/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/taskGuide/service/TaskGuideQueryServiceImpl.java
@@ -30,4 +30,5 @@ public class TaskGuideQueryServiceImpl implements TaskGuideQueryService {
         return taskGuideRepository.findAllByCourseId(courseId, pageable)
                 .map(TaskGuideConverter::taskGuideListResponseDTO);
     }
+
 }

--- a/src/main/java/com/codiapp/codi/domain/team/controller/TeamController.java
+++ b/src/main/java/com/codiapp/codi/domain/team/controller/TeamController.java
@@ -2,8 +2,10 @@ package com.codiapp.codi.domain.team.controller;
 
 import java.util.List;
 
+import com.codiapp.codi.domain.team.dto.response.TeamInfoResponseDTO;
 import com.codiapp.codi.domain.team.service.TeamCommandService;
 import com.codiapp.codi.domain.team.service.TeamQueryService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.codiapp.codi.domain.team.converter.TeamConverter;
@@ -72,4 +75,13 @@ public class TeamController {
         teamCommandService.leaveTeam(teamId, userId);
         return ApiResponse.of(SuccessStatus._OK, null);
     }
+
+    @GetMapping("/teams/course")
+    public ResponseEntity<ApiResponse<List<TeamInfoResponseDTO>>> getTeamsByCourse(
+            @RequestParam Long courseId
+    ) {
+        List<TeamInfoResponseDTO> response = teamQueryService.getTeamsByCourse(courseId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
 }

--- a/src/main/java/com/codiapp/codi/domain/team/converter/TeamConverter.java
+++ b/src/main/java/com/codiapp/codi/domain/team/converter/TeamConverter.java
@@ -3,6 +3,7 @@ package com.codiapp.codi.domain.team.converter;
 import com.codiapp.codi.domain.course.entity.Course;
 import com.codiapp.codi.domain.team.dto.request.TeamCreateRequestDTO;
 import com.codiapp.codi.domain.team.dto.response.TeamCreateResponseDTO;
+import com.codiapp.codi.domain.team.dto.response.TeamInfoResponseDTO;
 import com.codiapp.codi.domain.team.dto.response.TeamReadResponseDTO;
 import com.codiapp.codi.domain.team.entity.Team;
 import com.codiapp.codi.domain.team.entity.UserTeam;
@@ -44,5 +45,9 @@ public class TeamConverter {
                 .id(team.getId())
                 .name(team.getName())
                 .build();
+    }
+
+    public static TeamInfoResponseDTO toTeamInfoResponseDTO(Team team) {
+        return new TeamInfoResponseDTO(team.getId(), team.getName());
     }
 }

--- a/src/main/java/com/codiapp/codi/domain/team/dto/response/TeamInfoResponseDTO.java
+++ b/src/main/java/com/codiapp/codi/domain/team/dto/response/TeamInfoResponseDTO.java
@@ -1,0 +1,6 @@
+package com.codiapp.codi.domain.team.dto.response;
+
+public record TeamInfoResponseDTO(
+        Long teamid,
+        String name
+) {}

--- a/src/main/java/com/codiapp/codi/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/team/repository/TeamRepository.java
@@ -3,6 +3,8 @@ package com.codiapp.codi.domain.team.repository;
 import com.codiapp.codi.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamRepository extends JpaRepository<Team, Long> {
+import java.util.List;
 
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    List<Team> findAllByCourseId(Long courseId);
 }

--- a/src/main/java/com/codiapp/codi/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/codiapp/codi/domain/team/repository/TeamRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findAllByCourseId(Long courseId);
+    List<Team> findByCourseId(Long courseId);
 }

--- a/src/main/java/com/codiapp/codi/domain/team/service/TeamQueryService.java
+++ b/src/main/java/com/codiapp/codi/domain/team/service/TeamQueryService.java
@@ -1,5 +1,6 @@
 package com.codiapp.codi.domain.team.service;
 
+import com.codiapp.codi.domain.team.dto.response.TeamInfoResponseDTO;
 import com.codiapp.codi.domain.team.dto.response.UserNameResponseDTO;
 import com.codiapp.codi.domain.team.entity.Team;
 
@@ -10,4 +11,5 @@ public interface TeamQueryService {
     List<Team> getTeamsByUserId(Long userId);
     List<String> getUserNamesByTeamId(Long teamId);
     List<UserNameResponseDTO> getUserInfosByTeamId(Long teamId);
+    List<TeamInfoResponseDTO> getTeamsByCourse(Long courseId);
 }

--- a/src/main/java/com/codiapp/codi/domain/team/service/TeamQueryServiceImpl.java
+++ b/src/main/java/com/codiapp/codi/domain/team/service/TeamQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.codiapp.codi.domain.team.service;
 
+import com.codiapp.codi.domain.team.converter.TeamConverter;
+import com.codiapp.codi.domain.team.dto.response.TeamInfoResponseDTO;
 import com.codiapp.codi.domain.team.dto.response.UserNameResponseDTO;
 import com.codiapp.codi.domain.team.entity.Team;
 import com.codiapp.codi.domain.team.entity.UserTeam;
@@ -49,5 +51,13 @@ public class TeamQueryServiceImpl implements TeamQueryService {
                         .userName(ut.getUser().getUsername())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<TeamInfoResponseDTO> getTeamsByCourse(Long courseId) {
+        List<Team> teams = teamRepository.findByCourseId(courseId);
+        return teams.stream()
+                .map(TeamConverter::toTeamInfoResponseDTO)
+                .toList();
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #45

## 📝 작업 내용
-   학생 task와 교수의 taskGuide연결 그 과정에서 로직이 복잡해 자동화가 안돼서 버튼으로 대체

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
교수자 입장에서 리스트2개 (확인용, 작성용) 각 리스트마다 단일 화면 볼 수 있고 확인용은 편집기능없이 확인만 가능
확인용 리스트의 조건은 같은 수업, 해당 팀, 과제상태 완료여야합니다.
작성용은 추가로 공지 버튼을 만들어 만든이후에 버튼을 누르면 해당 수업을 듣고 있는 팀들에게 과제가 자동으로 제공됩니다.
학생 로그인된 리스트에서 바로 확인 가능 

현재 올바른 로직으로는 잘 작동이 되는데 다양한 예외 처리는 아직 하지 못한 상태입니다.